### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           # This uses the version string from __about__.py, which we checked matches the git tag above
-          python setup.py sdist
-          twine upload dist/* --verbose
+          pip install build
+          python -m build
+          twine upload dist/*


### PR DESCRIPTION
This PR updates the PyPI deployment workflow to replace the python setup.py sdist with python -m build, which ensures PEP 625-compliant filenames.